### PR TITLE
Adding .gitattributes file to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+lib/* linguist-vendored
+docs/* linguist-documentation
+tex/* linguist-documentation


### PR DESCRIPTION
This should fix the fact that github's language stats are counting eigen.