### PR TITLE
Adding header to tutorial pages with link to ipynb

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,13 @@ extensions = [
     'nbsphinx'
 ]
 
+nbsphinx_prolog = """
+{% set docname = env.doc2path(env.docname, base=None) %}
+
+.. note:: This tutorial was generated from an Jupyter notebook that can be
+          downloaded `here <https://github.com/rodluger/starry/blob/master/docs/tutorials/{{ docname }}>`_.
+"""
+
 todo_include_todos = True
 
 autosummary_generate = True


### PR DESCRIPTION
I've never tried this, but nbsphinx includes the option to have a "prolog" on each page.