### PR TITLE
Adding MANIFEST file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md LICENSE HISTORY.rst
+include starry/*.h
+graft lib


### PR DESCRIPTION
This forces the source distribution to include the libraries and headers that it needs to compile properly using pip.