### PR TITLE
Added "using std::isinf" to solver.h

### DIFF
--- a/starry/solver.h
+++ b/starry/solver.h
@@ -25,6 +25,7 @@ namespace solver {
     using std::swap;
     using std::vector;
     using std::min;
+    using std::isinf;
 
     // Forward declaration
     template <class T>


### PR DESCRIPTION
Attempted fix for the following install error message:

```bash
starry/solver.h:136:31: error: ‘isinf’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
```