### PR TITLE
Patch for std::isinf

### DIFF
--- a/starry/orbital.h
+++ b/starry/orbital.h
@@ -29,6 +29,7 @@ namespace orbital {
     using std::string;
     using std::to_string;
     using std::fmod;
+    using std::isinf;
 
     template <class T> class Body;
     template <class T> class System;


### PR DESCRIPTION
Added `using std::isinf` to `orbital.h` to fix compile errors on certain machines.