### PR TITLE
Fixing reference count issue

### DIFF
--- a/starry/pybind_interface.h
+++ b/starry/pybind_interface.h
@@ -1094,11 +1094,13 @@ namespace pybind_interface {
         System
 
             // Constructor: one secondary
-            .def(py::init<kepler::Primary<T>*, kepler::Secondary<T>*>())
+            .def(py::init<kepler::Primary<T>*, kepler::Secondary<T>*>(),
+                 py::keep_alive<1, 2>(), py::keep_alive<1, 3>())
 
             // Constructor: multiple secondaries
             .def(py::init<kepler::Primary<T>*,
-                          std::vector<kepler::Secondary<T>*>>())
+                          std::vector<kepler::Secondary<T>*>>(),
+                 py::keep_alive<1, 2>(), py::keep_alive<1, 3>())
 
             .def_property_readonly("primary", [](kepler::System<T> &system) {
                 return system.primary;

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+from starry.kepler import Primary, Secondary, System
+
+
+def get_system(n_sec=1):
+    primary = Primary()
+    secondaries = []
+    for i in range(n_sec):
+        secondaries.append(Secondary())
+    return System(primary, *secondaries)
+
+
+def test_memory():
+    system = get_system()
+    system.compute(np.linspace(0, 5, 10))
+
+    system = get_system(2)
+    system.compute(np.linspace(0, 5, 10))


### PR DESCRIPTION
We needed pybind to tell Python that we need to keep a reference to the primary and secondaries in system.