### PR TITLE
Vectorize the luminosity of Secondary objects

### DIFF
--- a/starry/kepler.h
+++ b/starry/kepler.h
@@ -2049,7 +2049,7 @@ namespace kepler {
             setRow(secondary->dflux_cur, g, Row<T>(
                    getRow(secondary->dflux_cur, g) -
                    getRow(secondary->dflux_tot, g) +
-                   cwiseQuotient(secondary->flux_tot, secondary->L)));
+                   cwiseQuotient(secondary->flux_cur, secondary->L)));
             g++;
 
             // dF / dprot
@@ -2290,7 +2290,7 @@ namespace kepler {
                setRow(secondary->dflux_cur, g, Row<T>(
                       getRow(secondary->dflux_cur, g) -
                       getRow(secondary->dflux_tot, g) +
-                      cwiseQuotient(secondary->flux_tot, secondary->L)));
+                      cwiseQuotient(secondary->flux_cur, secondary->L)));
                g++;
 
                // dF / dprot

--- a/starry/kepler.h
+++ b/starry/kepler.h
@@ -487,7 +487,7 @@ namespace kepler {
     template <class T>
     inline void Body<T>::computeTotal(const Scalar<T>& time, bool gradient, bool numerical) {
         if (!allZero(L)) {
-            flux_tot = L * getFlux(theta_deg(time), 0, 0, 0, gradient, numerical);
+            flux_tot = cwiseProduct(L, getFlux(theta_deg(time), 0, 0, 0, gradient, numerical));
         } else {
             setZero(flux_tot);
         }
@@ -499,7 +499,7 @@ namespace kepler {
     inline void Body<T>::occult(const Scalar<T>& time, const Scalar<T>& xo,
                                 const Scalar<T>& yo, const Scalar<T>& ro,
                                 bool gradient, bool numerical) {
-        flux_cur += L * getFlux(theta_deg(time), xo, yo, ro, gradient, numerical)
+        flux_cur += cwiseProduct(L, getFlux(theta_deg(time), xo, yo, ro, gradient, numerical))
                     - flux_tot;
     }
 

--- a/starry/pybind_interface.h
+++ b/starry/pybind_interface.h
@@ -159,7 +159,7 @@ namespace pybind_interface {
              }, docstrings::Map::load_image, "image"_a, "lmax"_a=-1)
 
              .def("load_healpix", [](maps::Map<T> &map,
-                                     const Matrix<double>& image,
+                                     const Vector<double>& image,
                                      int lmax) {
                  py::object load_map =
                     py::module::import("starry.maps").attr("load_map");
@@ -368,7 +368,7 @@ namespace pybind_interface {
                 map.setAxis(map_axis);
             }, docstrings::Map::load_image, "image"_a, "nwav"_a=0, "lmax"_a=-1)
 
-            .def("load_healpix", [](maps::Map<T> &map, std::string& image,
+            .def("load_healpix", [](maps::Map<T> &map, const Vector<double>& image,
                                   int nwav, int lmax) {
                 py::object load_map =
                     py::module::import("starry.maps").attr("load_map");

--- a/starry/pybind_interface.h
+++ b/starry/pybind_interface.h
@@ -240,7 +240,7 @@ namespace pybind_interface {
         Map
 
             .def("show", [](maps::Map<T> &map, std::string cmap,
-                            int res, std::string& gif) -> py::object {
+                            int res, std::string& gif, bool show_labels) -> py::object {
                 std::cout << "Rendering..." << std::endl;
                 py::object animate =
                     py::module::import("starry.maps").attr("animate");
@@ -267,10 +267,14 @@ namespace pybind_interface {
                         }
                     }
                 }
-                return animate(I, "cmap"_a=cmap, "res"_a=res, "gif"_a=gif,
-                                  "labels"_a=labels, "interval"_a=interval);
+                if (show_labels)
+                    return animate(I, "cmap"_a=cmap, "res"_a=res, "gif"_a=gif,
+                                      "labels"_a=labels, "interval"_a=interval);
+                else
+                    return animate(I, "cmap"_a=cmap, "res"_a=res, "gif"_a=gif,
+                                      "interval"_a=interval);
             }, docstrings::Map::show, "cmap"_a="plasma",
-               "res"_a=150, "gif"_a="")
+               "res"_a=150, "gif"_a="", "show_labels"_a=true)
 
             .def("load_image", [](maps::Map<T> &map,
                                   const Matrix<double>& image,

--- a/starry/pybind_interface.h
+++ b/starry/pybind_interface.h
@@ -649,6 +649,15 @@ namespace pybind_interface {
 
         Body
 
+            // Luminosity in units of primary luminosity
+            .def_property("L",
+                [](kepler::Body<T> &body) {
+                    return static_cast<double>(body.getLuminosity());
+                },
+                [](kepler::Body<T> &body, const double& L){
+                    body.setLuminosity(Scalar<T>(L));
+                }, docstrings::Body::L)
+
             // The gradient of the light curve: a dictionary of matrices/vectors
             // NOTE: This may be slow because we need to swap some axes here:
             //      dL(NT)(ngrad, nwav) --> gradient(ngrad)(NT, nwav)
@@ -732,6 +741,15 @@ namespace pybind_interface {
 
         Body
 
+            // Luminosity in units of primary luminosity
+            .def_property("L",
+                [](kepler::Body<T> &body) {
+                    return body.getLuminosity().template cast<double>();
+                },
+                [](kepler::Body<T> &body, const Vector<double>& L){
+                    body.setLuminosity(L.template cast<Scalar<T>>());
+                }, docstrings::Body::L)
+
             // The gradient of the light curve: a dictionary of matrices/vectors
             // NOTE: This may be slow because we need to swap some axes here:
             //      dL(NT)(ngrad, nwav) --> gradient(ngrad)(NT, nwav)
@@ -810,15 +828,6 @@ namespace pybind_interface {
                     body.setRadius(r);
                 }, docstrings::Body::r)
 
-            // Luminosity in units of primary luminosity
-            .def_property("L",
-                [](kepler::Body<T> &body) {
-                    return static_cast<double>(body.getLuminosity());
-                },
-                [](kepler::Body<T> &body, const double& L){
-                    body.setLuminosity(L);
-                }, docstrings::Body::L)
-
             // Rotation period in days
             .def_property("prot",
                 [](kepler::Body<T> &body) {
@@ -856,6 +865,50 @@ namespace pybind_interface {
     }
 
     /**
+    Add type-specific features to the Body class: single-wavelength starry.
+
+    */
+    template <typename T>
+    typename std::enable_if<!std::is_base_of<Eigen::EigenBase<Row<T>>,
+                                            Row<T>>::value, void>::type
+    addPrimaryExtras(py::class_<kepler::Primary<T>>& Primary) {
+
+        Primary
+
+            // Luminosity in units of primary luminosity
+            .def_property("L",
+                [](kepler::Primary<T> &body) {
+                    return static_cast<double>(body.getLuminosity());
+                },
+                [](kepler::Primary<T> &body, const double& L){
+                    body.setLuminosity(Scalar<T>(L));
+                }, docstrings::Primary::L);
+
+    }
+
+    /**
+    Add type-specific features to the Body class: spectral starry.
+
+    */
+    template <typename T>
+    typename std::enable_if<std::is_base_of<Eigen::EigenBase<Row<T>>,
+                                            Row<T>>::value, void>::type
+    addPrimaryExtras(py::class_<kepler::Primary<T>>& Primary) {
+
+        Primary
+
+            // Luminosity in units of primary luminosity
+            .def_property("L",
+                [](kepler::Primary<T> &body) {
+                    return body.getLuminosity().template cast<double>();
+                },
+                [](kepler::Primary<T> &body, const Vector<double>& L){
+                    body.setLuminosity(L.template cast<Scalar<T>>());
+                }, docstrings::Primary::L);
+
+    }
+
+    /**
     The pybind wrapper for the Primary class.
 
     */
@@ -883,15 +936,6 @@ namespace pybind_interface {
                     body.setRadius(r);
                 }, docstrings::Primary::r)
 
-            // Luminosity in units of primary luminosity
-            .def_property("L",
-                [](kepler::Primary<T> &body) {
-                    return static_cast<double>(body.getLuminosity());
-                },
-                [](kepler::Primary<T> &body, const double& L){
-                    body.setLuminosity(L);
-                }, docstrings::Primary::L)
-
             // Radius in meters (sets a scale for light travel time delay)
             .def_property("r_m",
                 [](kepler::Primary<T> &body) {
@@ -900,6 +944,9 @@ namespace pybind_interface {
                 [](kepler::Primary<T> &body, const double& r_m){
                     body.setRadiusInMeters(r_m);
                 }, docstrings::Primary::r_m);
+
+        // Add type-specific attributes & methods
+        addPrimaryExtras(Primary);
 
         return Primary;
 


### PR DESCRIPTION
For spectral `starry`, the `Secondary` luminosity should be a vector, with a value at each wavelength. This patch implements this.