### PR TITLE
mybinder.org setup experiment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,16 +1,16 @@
 dependencies:
-- numpy
-- scipy
-- matplotlib
-- setuptools
-- pybind11
-- healpy
-- nbsphinx
-- pip:
- - Pillow
- - batman-package
- - tqdm
- - emcee
- - corner
- - wget
- - pandas
+  - numpy
+  - scipy
+  - matplotlib
+  - setuptools
+  - pybind11
+  - healpy
+  - nbsphinx
+  - pip:
+    - Pillow
+    - batman-package
+    - tqdm
+    - emcee
+    - corner
+    - wget
+    - pandas

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,16 @@
+dependencies:
+- numpy
+- scipy
+- matplotlib
+- setuptools
+- pybind11
+- healpy
+- nbsphinx
+- pip:
+ - Pillow
+ - batman-package
+ - tqdm
+ - emcee
+ - corner
+ - wget
+ - pandas

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+pip install git+git://github.com/tomlouden/SPIDERMAN.git@69911b042bc46615ec9b39048a69e0d77c8542ad

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,2 @@
 pip install git+git://github.com/tomlouden/SPIDERMAN.git@69911b042bc46615ec9b39048a69e0d77c8542ad
+pip install -e.


### PR DESCRIPTION
Hey 👋!

I wanted to know how hard it would be to get this to run on mybinder.org. So this is a quick experiment on doing that. As far as I can tell the demos run, I've not tested it further yet.

Link to try it out: https://mybinder.org/v2/gh/betatim/starry/master?filepath=docs%2Ftutorials%2Fbasics3.ipynb

Do you know how to fix the fact that I have to `show()` two stars before it actually appears in the notebook output? Seems like I forgot to install/enable some extension?


All the files needed for mybinder.org are in the `binder/` sub-directory so they don't get in the way with any other files specifying dependencies and such. We could also move them up to the root if that is preferred. If we wanted to do this properly we should pin the versions of the dependencies.